### PR TITLE
Implement summary of flaky reports

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,7 @@ jobs:
       - name: Bump dependency version used in JBang script to the released version
         run: |
           sed -i "s#DEPS io.quarkus.qe:flaky-run-reporter:.*#DEPS io.quarkus.qe:flaky-run-reporter:${{steps.metadata.outputs.current-version}}#" ./jbang-scripts/FlakyTestRunSummarizer.java
+          git commit -am "Update JBang script dependency version to ${{steps.metadata.outputs.current-version}}"
       - name: Push changes to ${{github.base_ref}}
         uses: ad-m/github-push-action@v0.8.0
         with:

--- a/README.md
+++ b/README.md
@@ -26,8 +26,19 @@ You may want to summarize past flaky run reports into one report:
 
 ```bash
 jbang trust add https://raw.githubusercontent.com/quarkus-qe/flaky-run-reporter
-jbang https://raw.githubusercontent.com/quarkus-qe/flaky-run-reporter/main/jbang-scripts/FlakyTestRunSummarizer.java day-retention=30 max-flakes-per-test=50 summary-report-path=./summary.json new-build-report-path=./new.json
+jbang https://raw.githubusercontent.com/quarkus-qe/flaky-run-reporter/main/jbang-scripts/FlakyTestRunSummarizer.java day-retention=30 new-flaky-report-path=target/flaky-run-report.json
 ```
+Following script arguments are supported:
 
-Please note that script arguments are optional.
-We set sensible defaults for you.
+| Argument name                | Argument description                               | Default value               |
+|------------------------------|----------------------------------------------------|-----------------------------|
+| day-retention                | Max days flaky results are kept                    | 30                          |
+| max-flakes-per-test          | Max flaky results per one flaky test               | 50                          |
+| previous-summary-report-path | Path to a previous summary report                  | ./flaky-summary-report.json |
+| new-flaky-report-path        | Path to the latest flaky report added to a summary | ./flaky-run-report.json     |
+| flaky-report-ci-job-name     | Jenkins job name or GitHub action name             | \<\<empty>>                 |
+| flaky-report-ci-build-number | Jenkins job or GitHub action build number          | \<\<empty>>                 |
+| new-summary-report-path      | Jenkins job or GitHub action build number          | ./flaky-summary-report.json |
+
+Please note that all script arguments are optional.
+The JBang script requires new flaky report to exist, as the whole point of the script is to add new report to a summary.

--- a/src/main/java/io/quarkus/qe/reporter/flakyrun/reporter/FlakyRunReporter.java
+++ b/src/main/java/io/quarkus/qe/reporter/flakyrun/reporter/FlakyRunReporter.java
@@ -33,8 +33,7 @@ public class FlakyRunReporter {
         this.logger = logger;
     }
 
-    public static List<FlakyTest> parseFlakyTestsReport(String reportPathStr) {
-        Path reportPath = Path.of(reportPathStr);
+    public static List<FlakyTest> parseFlakyTestsReport(Path reportPath) {
         if (!Files.exists(reportPath)) {
             return List.of();
         }

--- a/src/main/java/io/quarkus/qe/reporter/flakyrun/summary/FlakyRunSummary.java
+++ b/src/main/java/io/quarkus/qe/reporter/flakyrun/summary/FlakyRunSummary.java
@@ -1,11 +1,23 @@
 package io.quarkus.qe.reporter.flakyrun.summary;
 
+import java.time.ZonedDateTime;
 import java.util.List;
 
-public record FlakyRunSummary(String projectName, String projectBaseDir, String testFullName,
-        List<FlakyRunSummaryItem> flakes) {
+public record FlakyRunSummary(List<FlakyRunProjectSummary> flakyProjects) {
+    public record FlakyRunProjectSummary(String projectName, String projectBaseDir,
+            List<FlakyRunTestSummary> flakeTests) {
+    }
 
-    public record FlakyRunSummaryItem(String failureMessage, String failureType, String failureStackTrace,
-            String dateTime) {
+    public record FlakyRunTestSummary(String fullTestName, List<FlakyRunFlake> flakes) {
+    }
+
+    public record FlakyRunFlake(String failureMessage, String failureType, String failureStackTrace, String dateTime,
+            String ciJobName, String ciBuildNumber) implements Comparable<FlakyRunFlake> {
+        @Override
+        public int compareTo(FlakyRunFlake that) {
+            ZonedDateTime thatDateTime = ZonedDateTime.parse(that.dateTime());
+            ZonedDateTime thisDateTime = ZonedDateTime.parse(dateTime());
+            return thisDateTime.compareTo(thatDateTime);
+        }
     }
 }

--- a/src/main/java/io/quarkus/qe/reporter/flakyrun/summary/FlakyRunSummaryReporter.java
+++ b/src/main/java/io/quarkus/qe/reporter/flakyrun/summary/FlakyRunSummaryReporter.java
@@ -1,24 +1,52 @@
 package io.quarkus.qe.reporter.flakyrun.summary;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import io.quarkus.qe.reporter.flakyrun.reporter.FlakyRunReporter;
+import io.quarkus.qe.reporter.flakyrun.reporter.FlakyTest;
+import io.quarkus.qe.reporter.flakyrun.summary.FlakyRunSummary.FlakyRunProjectSummary;
+
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static java.util.stream.Collectors.groupingBy;
 
 public class FlakyRunSummaryReporter {
     public static final String FLAKY_SUMMARY_REPORT = "flaky-summary-report.json";
+    private static final Path CURRENT_DIR = Path.of(".");
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper().enable(SerializationFeature.INDENT_OUTPUT);
     private static final String DAY_RETENTION = "day-retention";
     private static final String MAX_FLAKES_PER_TEST = "max-flakes-per-test";
-    private static final String SUMMARY_REPORT_PATH = "summary-report-path";
-    private static final String NEW_BUILD_REPORT_PATH = "new-build-report-path";
+    private static final String PREVIOUS_SUMMARY_REPORT_PATH = "previous-summary-report-path";
+    private static final String NEW_SUMMARY_REPORT_PATH = "new-summary-report-path";
+    private static final String NEW_FLAKY_REPORT_PATH = "new-flaky-report-path";
     private static final String EQUALS = "=";
+    private static final String CI_JOB_NAME = "flaky-report-ci-job-name";
+    private static final String CI_BUILD_NUMBER = "flaky-report-ci-build-number";
     private final int dayRetention;
     private final int maxFlakesPerTest;
-    private final String newBuildReportPath;
-    private final String summaryReportPath;
+    private final Path newBuildReportPath;
+    private final Path previousSummaryReportPath;
+    private final String ciJobName;
+    private final int ciJobBuildNumber;
+    private final Path newSummaryReportPath;
 
     public FlakyRunSummaryReporter(String[] args) {
         int dayRetention = 30;
         int maxFlakesPerTest = 50;
-        String newBuildReportPath = FlakyRunReporter.FLAKY_RUN_REPORT;
-        String summaryReportPath = FLAKY_SUMMARY_REPORT;
+        Path newBuildReportPath = CURRENT_DIR.resolve(FlakyRunReporter.FLAKY_RUN_REPORT);
+        Path previousSummaryReportPath = CURRENT_DIR.resolve(FLAKY_SUMMARY_REPORT);
+        Path newSummaryReportPath = CURRENT_DIR.resolve(FLAKY_SUMMARY_REPORT);
+        String ciJobName = "";
+        int ciJobBuildNumber = -1;
         for (String arg : args) {
             if (isArgument(DAY_RETENTION, arg)) {
                 dayRetention = parseIntArgument(DAY_RETENTION, arg);
@@ -26,22 +54,146 @@ public class FlakyRunSummaryReporter {
             if (isArgument(MAX_FLAKES_PER_TEST, arg)) {
                 maxFlakesPerTest = parseIntArgument(MAX_FLAKES_PER_TEST, arg);
             }
-            if (isArgument(NEW_BUILD_REPORT_PATH, arg)) {
-                newBuildReportPath = parseStringArgument(NEW_BUILD_REPORT_PATH, arg);
+            if (isArgument(NEW_FLAKY_REPORT_PATH, arg)) {
+                newBuildReportPath = Path.of(parseStringArgument(NEW_FLAKY_REPORT_PATH, arg));
             }
-            if (isArgument(SUMMARY_REPORT_PATH, arg)) {
-                summaryReportPath = parseStringArgument(SUMMARY_REPORT_PATH, arg);
+            if (isArgument(PREVIOUS_SUMMARY_REPORT_PATH, arg)) {
+                previousSummaryReportPath = Path.of(parseStringArgument(PREVIOUS_SUMMARY_REPORT_PATH, arg));
             }
-
+            if (isArgument(CI_BUILD_NUMBER, arg)) {
+                ciJobBuildNumber = parseIntArgument(CI_BUILD_NUMBER, arg);
+            }
+            if (isArgument(CI_JOB_NAME, arg)) {
+                ciJobName = parseStringArgument(CI_JOB_NAME, arg);
+            }
+            if (isArgument(NEW_SUMMARY_REPORT_PATH, arg)) {
+                newSummaryReportPath = Path.of(parseStringArgument(NEW_SUMMARY_REPORT_PATH, arg));
+            }
         }
         this.dayRetention = dayRetention;
         this.maxFlakesPerTest = maxFlakesPerTest;
         this.newBuildReportPath = newBuildReportPath;
-        this.summaryReportPath = summaryReportPath;
+        this.previousSummaryReportPath = previousSummaryReportPath;
+        this.ciJobName = ciJobName;
+        this.ciJobBuildNumber = ciJobBuildNumber;
+        this.newSummaryReportPath = newSummaryReportPath;
     }
 
     public void createReport() {
+        List<FlakyTest> flakyTests = FlakyRunReporter.parseFlakyTestsReport(newBuildReportPath);
+        if (!flakyTests.isEmpty()) {
+            var previousSummaries = toProjectSummaries(parsePreviousSummary(previousSummaryReportPath));
+            var newSummary = createNewSummary(previousSummaries, flakyTests);
+            saveSummaryToFileSystem(newSummary);
+        }
+    }
 
+    private FlakyRunSummary createNewSummary(List<FlakyRunProjectSummary> existingProjects,
+            List<FlakyTest> newFlakyTests) {
+        List<FlakyRunProjectSummary> projectSummaries = new ArrayList<>(flakyTestsToSummaries(newFlakyTests));
+        if (!existingProjects.isEmpty()) {
+            projectSummaries.addAll(existingProjects);
+        }
+        // if there is one project multiple times, merge the project summaries into one
+        projectSummaries = mergeProjectSummaries(projectSummaries);
+        return new FlakyRunSummary(List.copyOf(projectSummaries));
+    }
+
+    private List<FlakyRunProjectSummary> flakyTestsToSummaries(List<FlakyTest> flakyTests) {
+        // at this point: one flaky tests == one flaky summary
+        return flakyTests.stream().map(this::createProjectSummaryFromFlakyTest).toList();
+    }
+
+    private FlakyRunProjectSummary createProjectSummaryFromFlakyTest(FlakyTest flakyTest) {
+        return new FlakyRunProjectSummary(flakyTest.projectName(), flakyTest.projectBaseDir(),
+                createFlakyTestSummaryFromTest(flakyTest));
+    }
+
+    private List<FlakyRunSummary.FlakyRunTestSummary> createFlakyTestSummaryFromTest(FlakyTest flakyTest) {
+        return List.of(
+                new FlakyRunSummary.FlakyRunTestSummary(flakyTest.fullTestName(), createFlakyRunFromTest(flakyTest)));
+    }
+
+    private List<FlakyRunSummary.FlakyRunFlake> createFlakyRunFromTest(FlakyTest flakyTest) {
+        return List.of(new FlakyRunSummary.FlakyRunFlake(flakyTest.failureMessage(), flakyTest.failureType(),
+                flakyTest.failureStackTrace(), flakyTest.dateTime(), ciJobName, Integer.toString(ciJobBuildNumber)));
+    }
+
+    private List<FlakyRunProjectSummary> mergeProjectSummaries(List<FlakyRunProjectSummary> projectSummaries) {
+        record FlakyRunProjectInfo(String projectName, String baseDir) {
+        }
+        return projectSummaries.stream()
+                .collect(groupingBy(s -> new FlakyRunProjectInfo(s.projectName(), s.projectBaseDir()),
+                        Collectors.toList()))
+                .entrySet().stream()
+                .map(entry -> new FlakyRunProjectSummary(entry.getKey().projectName(), entry.getKey().baseDir(),
+                        mergeTestSummaries(entry.getValue())))
+                // at this point: projects are grouped by project name
+                .toList();
+    }
+
+    private List<FlakyRunSummary.FlakyRunTestSummary> mergeTestSummaries(
+            List<FlakyRunProjectSummary> projectSummaries) {
+        return projectSummaries.stream().map(FlakyRunProjectSummary::flakeTests).flatMap(Collection::stream)
+                .collect(Collectors.groupingBy(FlakyRunSummary.FlakyRunTestSummary::fullTestName, Collectors.toList()))
+                .entrySet().stream()
+                .map(s -> new FlakyRunSummary.FlakyRunTestSummary(s.getKey(), filterTestFlakes(s.getValue()))).toList();
+    }
+
+    private List<FlakyRunSummary.FlakyRunFlake> filterTestFlakes(
+            List<FlakyRunSummary.FlakyRunTestSummary> testSummaries) {
+        ZonedDateTime dayRetentionDateTime = ZonedDateTime.now().minusDays(this.dayRetention);
+        return testSummaries.stream().map(FlakyRunSummary.FlakyRunTestSummary::flakes).flatMap(Collection::stream)
+                .map(s -> new FlakyRunSummary.FlakyRunFlake(s.failureMessage(), s.failureType(), s.failureStackTrace(),
+                        s.dateTime(), s.ciJobName(), s.ciBuildNumber()))
+                // flakes sorted in descending order
+                .sorted(new Comparator<FlakyRunSummary.FlakyRunFlake>() {
+                    @Override
+                    public int compare(FlakyRunSummary.FlakyRunFlake o1, FlakyRunSummary.FlakyRunFlake o2) {
+                        return o1.compareTo(o2);
+                    }
+                }.reversed()).limit(maxFlakesPerTest)
+                .filter(flake -> ZonedDateTime.parse(flake.dateTime()).isAfter(dayRetentionDateTime)).toList();
+    }
+
+    private void saveSummaryToFileSystem(FlakyRunSummary summary) {
+        if (Files.exists(newSummaryReportPath)) {
+            try {
+                Files.delete(newSummaryReportPath);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        try (FileOutputStream file = new FileOutputStream(newSummaryReportPath.toFile())) {
+            OBJECT_MAPPER.writeValue(file, summary);
+        } catch (Exception e) {
+            System.err.println("Unable to create the %s file: %s" + e);
+        }
+    }
+
+    private static List<FlakyRunProjectSummary> toProjectSummaries(FlakyRunSummary previousSummary) {
+        final List<FlakyRunProjectSummary> flakyProjects;
+        if (previousSummary != null && previousSummary.flakyProjects() != null) {
+            flakyProjects = List.copyOf(previousSummary.flakyProjects());
+        } else {
+            flakyProjects = List.of();
+        }
+        return flakyProjects;
+    }
+
+    private static FlakyRunSummary parsePreviousSummary(Path summaryPath) {
+        if (Files.exists(summaryPath) && Files.isRegularFile(summaryPath)) {
+            try {
+                return OBJECT_MAPPER.readValue(summaryPath.toFile(), FlakyRunSummary.class);
+            } catch (IOException e) {
+                // previous summary path is not required, however should at least inform something went wrong
+                System.err.printf("""
+                        Detected previous summary report on path '%s',
+                        however the file is not deserializable and will be ignored: %s
+                        %n""", summaryPath, e.getMessage());
+            }
+        }
+        return null;
     }
 
     private static boolean isArgument(String argumentKey, String argument) {


### PR DESCRIPTION
### Summary

Provides basic functionality to merge flaky reports and keep information about CI job and run date time.
This summary is supposed to be invoked from the JBang script.

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)