### PR TITLE
Migrate deprecated CodeHaus container to Sisu container

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,8 +15,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven-core.version>3.9.9</maven-core.version>
         <maven-surefire-report-parser.version>3.5.0</maven-surefire-report-parser.version>
-        <plexus-containers.version>2.2.0</plexus-containers.version>
         <jackson-databind.version>2.17.0</jackson-databind.version>
+        <sisu-plugin.version>0.9.0.M3</sisu-plugin.version>
         <formatter-maven-plugin.version>2.24.1</formatter-maven-plugin.version>
         <!-- Format Settings -->
         <src.format.goal>format</src.format.goal>
@@ -31,11 +31,7 @@
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-core</artifactId>
             <version>${maven-core.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.codehaus.plexus</groupId>
-            <artifactId>plexus-component-annotations</artifactId>
-            <version>${plexus-containers.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
@@ -64,14 +60,15 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.codehaus.plexus</groupId>
-                <artifactId>plexus-component-metadata</artifactId>
-                <!-- FIXME: replace this deprecated dependency -->
-                <version>2.2.0</version>
+                <groupId>org.eclipse.sisu</groupId>
+                <artifactId>sisu-maven-plugin</artifactId>
+                <version>${sisu-plugin.version}</version>
                 <executions>
                     <execution>
+                        <id>generate-index</id>
                         <goals>
-                            <goal>generate-metadata</goal>
+                            <goal>main-index</goal>
+                            <goal>test-index</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/src/main/java/io/quarkus/qe/reporter/flakyrun/mavenextension/FlakyRunReportingMavenExtension.java
+++ b/src/main/java/io/quarkus/qe/reporter/flakyrun/mavenextension/FlakyRunReportingMavenExtension.java
@@ -4,18 +4,20 @@ import io.quarkus.qe.reporter.flakyrun.reporter.FlakyRunReporter;
 import io.quarkus.qe.reporter.flakyrun.reporter.Project;
 import org.apache.maven.AbstractMavenLifecycleParticipant;
 import org.apache.maven.execution.MavenSession;
-import org.codehaus.plexus.component.annotations.Component;
-import org.codehaus.plexus.component.annotations.Requirement;
 import org.codehaus.plexus.logging.Logger;
 
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
 import java.nio.file.Path;
 import java.util.List;
 
-@Component(role = AbstractMavenLifecycleParticipant.class, hint = "quarkus-qe-flaky-run-reporter")
+@Singleton
+@Named("quarkus-qe-flaky-run-reporter")
 public class FlakyRunReportingMavenExtension extends AbstractMavenLifecycleParticipant {
 
-    @Requirement
-    private Logger logger;
+    @Inject
+    public Logger logger;
 
     @Override
     public void afterSessionEnd(MavenSession session) {

--- a/src/main/java/io/quarkus/qe/reporter/flakyrun/mavenextension/FlakyRunReportingMavenExtension.java
+++ b/src/main/java/io/quarkus/qe/reporter/flakyrun/mavenextension/FlakyRunReportingMavenExtension.java
@@ -21,7 +21,7 @@ public class FlakyRunReportingMavenExtension extends AbstractMavenLifecycleParti
 
     @Override
     public void afterSessionEnd(MavenSession session) {
-        logger.debug("Flaky run reporter started");
+        logger.info("Flaky run reporter started");
 
         var projects = getProjectsFromMvnSession(session);
         if (!projects.isEmpty()) {


### PR DESCRIPTION
### Summary

All CodeHaus Plexu containers projects has been deprecated and not updated for a while now https://codehaus-plexus.github.io/plexus-containers/. So migrating to recommended option. I set dependencies scope to provided as I saw in here: https://maven.apache.org/examples/maven-3-lifecycle-extensions.html

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [x] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)