### PR TITLE
Add JBang script that will crunch Flaky Run reports and create comment that can be printed in GitHub PRs where flakiness occurred

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,10 +48,11 @@ jobs:
           git checkout ${{github.base_ref}}
           git rebase release
           mvn -B release:perform -DskipITs -DskipTests -Prelease,framework -s maven-settings.xml
-      - name: Bump dependency version used in JBang script to the released version
+      - name: Bump dependency version used in JBang scripts to the released version
         run: |
           sed -i "s#DEPS io.quarkus.qe:flaky-run-reporter:.*#DEPS io.quarkus.qe:flaky-run-reporter:${{steps.metadata.outputs.current-version}}#" ./jbang-scripts/FlakyTestRunSummarizer.java
-          git commit -am "Update JBang script dependency version to ${{steps.metadata.outputs.current-version}}"
+          sed -i "s#DEPS io.quarkus.qe:flaky-run-reporter:.*#DEPS io.quarkus.qe:flaky-run-reporter:${{steps.metadata.outputs.current-version}}#" ./jbang-scripts/GitHubPrCommentator.java
+          git commit -am "Update JBang scripts dependency version to ${{steps.metadata.outputs.current-version}}"
       - name: Push changes to ${{github.base_ref}}
         uses: ad-m/github-push-action@v0.8.0
         with:

--- a/jbang-scripts/GitHubPrCommentator.java
+++ b/jbang-scripts/GitHubPrCommentator.java
@@ -1,0 +1,16 @@
+//usr/bin/env jbang "$0" "$@" ; exit $?
+
+//DEPS io.quarkus.qe:flaky-run-reporter:0.1.2.Beta1
+
+import io.quarkus.qe.reporter.flakyrun.commentator.CreateGhPrComment;
+
+public class GitHubPrCommentator {
+    public static void main(String... args) {
+        try {
+            new CreateGhPrComment(args).printToStdOut();
+            System.exit(0);
+        } catch (Exception e) {
+            System.exit(1);
+        }
+    }
+}

--- a/src/main/java/io/quarkus/qe/reporter/flakyrun/FlakyReporterUtils.java
+++ b/src/main/java/io/quarkus/qe/reporter/flakyrun/FlakyReporterUtils.java
@@ -1,0 +1,58 @@
+package io.quarkus.qe.reporter.flakyrun;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public final class FlakyReporterUtils {
+
+    private static final String EQUALS = "=";
+
+    private FlakyReporterUtils() {
+    }
+
+    public static boolean isArgument(String argumentKey, String argument) {
+        return argument.startsWith(argumentKey + EQUALS);
+    }
+
+    public static int parseIntArgument(String argumentKey, String argument) {
+        return Integer.parseInt(argument.substring((argumentKey + EQUALS).length()));
+    }
+
+    public static String parseStringArgument(String argumentKey, String argument) {
+        return argument.substring((argumentKey + EQUALS).length());
+    }
+
+    public static String getRequiredArgument(String argumentKey, String[] arguments) {
+        String argument = null;
+        for (String a : arguments) {
+            if (a != null && isArgument(argumentKey, a)) {
+                argument = a;
+            }
+        }
+        if (argument == null) {
+            throw new IllegalArgumentException("Argument '" + argument + "' is missing");
+        }
+        return parseStringArgument(argumentKey, argument);
+    }
+
+    public static String readFile(Path overviewPath) {
+        try {
+            return Files.readString(overviewPath);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static String[] createCommandArgs(String... args) {
+        if (args.length % 2 != 0) {
+            throw new IllegalArgumentException("Args must be even");
+        }
+        String[] result = new String[args.length / 2];
+        for (int i = 0; i < result.length; i++) {
+            int j = i * 2;
+            result[i] = args[j] + EQUALS + args[j + 1];
+        }
+        return result;
+    }
+}

--- a/src/main/java/io/quarkus/qe/reporter/flakyrun/commentator/CreateGhPrComment.java
+++ b/src/main/java/io/quarkus/qe/reporter/flakyrun/commentator/CreateGhPrComment.java
@@ -1,0 +1,89 @@
+package io.quarkus.qe.reporter.flakyrun.commentator;
+
+import io.quarkus.qe.reporter.flakyrun.reporter.FlakyRunReporter;
+import io.quarkus.qe.reporter.flakyrun.reporter.FlakyTest;
+import io.quarkus.qe.reporter.flakyrun.summary.FlakyRunSummaryReporter;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static io.quarkus.qe.reporter.flakyrun.FlakyReporterUtils.getRequiredArgument;
+import static io.quarkus.qe.reporter.flakyrun.FlakyReporterUtils.readFile;
+
+/**
+ * This class is used by a Jbang script to simplify commenting in GitHub PRs when a flake were detected.
+ */
+public final class CreateGhPrComment {
+
+    public static final String TEST_BASE_DIR = CreateGhPrComment.class.getSimpleName() + ".test-base-dir";
+    public static final String OVERVIEW_FILE_KEY = "overview-file";
+    public static final String FLAKY_REPORTS_FILE_PREFIX_KEY = "flaky-reports-file-prefix";
+    private static final Path CURRENT_DIR = Path.of(".");
+    private final String comment;
+    private final Path baseDir;
+
+    public CreateGhPrComment(String[] args) {
+        if (System.getProperty(TEST_BASE_DIR) != null) {
+            baseDir = Path.of(System.getProperty(TEST_BASE_DIR));
+        } else {
+            baseDir = CURRENT_DIR;
+        }
+        var failureOverview = getFailureOverview(args);
+        var flakyTestsReports = getFlakyTestReports(args);
+        this.comment = """
+                Following jobs contain at least one flaky test: %s
+
+                %s
+                """.formatted(failureOverview, flakyTestsReports);
+    }
+
+    public String getComment() {
+        return comment;
+    }
+
+    public void printToStdOut() {
+        System.out.println(comment);
+    }
+
+    private String getFlakyTestReports(String[] args) {
+        var reportFilePrefix = getRequiredArgument(FLAKY_REPORTS_FILE_PREFIX_KEY, args);
+        var listOfDirFiles = baseDir.toFile().listFiles();
+        if (listOfDirFiles == null || listOfDirFiles.length == 0) {
+            return "No flaky test reports found";
+        }
+        var result = new StringBuilder();
+        for (File file : listOfDirFiles) {
+            if (file.getName().startsWith(reportFilePrefix)) {
+                var flakyTests = FlakyRunReporter.parseFlakyTestsReport(file.toPath());
+                if (!flakyTests.isEmpty()) {
+                    result.append("**Artifact `%s` contains following failures:**".formatted(file.getName()));
+                    for (FlakyTest flakyTest : flakyTests) {
+                        result.append("""
+
+                                - Test name: `%s`
+                                  Date and time: %s
+                                  Failure message: `%s`
+                                  Failure stacktrace:
+                                ```
+                                %s
+                                ```
+                                """.formatted(flakyTest.fullTestName(), flakyTest.dateTime(),
+                                flakyTest.failureMessage(), flakyTest.failureStackTrace()));
+                    }
+                    result.append(System.lineSeparator());
+                }
+            }
+        }
+        return result.toString();
+    }
+
+    private String getFailureOverview(String[] args) {
+        var overviewPath = baseDir.resolve(getRequiredArgument(OVERVIEW_FILE_KEY, args));
+        if (Files.exists(overviewPath)) {
+            return readFile(overviewPath);
+        }
+        throw new IllegalStateException("File '" + overviewPath + "' not found");
+    }
+}

--- a/src/main/java/io/quarkus/qe/reporter/flakyrun/summary/FlakyRunSummaryReporter.java
+++ b/src/main/java/io/quarkus/qe/reporter/flakyrun/summary/FlakyRunSummaryReporter.java
@@ -17,6 +17,9 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static io.quarkus.qe.reporter.flakyrun.FlakyReporterUtils.isArgument;
+import static io.quarkus.qe.reporter.flakyrun.FlakyReporterUtils.parseIntArgument;
+import static io.quarkus.qe.reporter.flakyrun.FlakyReporterUtils.parseStringArgument;
 import static java.util.stream.Collectors.groupingBy;
 
 public class FlakyRunSummaryReporter {
@@ -30,7 +33,6 @@ public class FlakyRunSummaryReporter {
     private static final String PREVIOUS_SUMMARY_REPORT_PATH = "previous-summary-report-path";
     private static final String NEW_SUMMARY_REPORT_PATH = "new-summary-report-path";
     private static final String NEW_FLAKY_REPORT_PATH = "new-flaky-report-path";
-    private static final String EQUALS = "=";
     private static final String CI_JOB_NAME = "flaky-report-ci-job-name";
     private final int dayRetention;
     private final int maxFlakesPerTest;
@@ -201,17 +203,5 @@ public class FlakyRunSummaryReporter {
             }
         }
         return null;
-    }
-
-    private static boolean isArgument(String argumentKey, String argument) {
-        return argument.startsWith(argumentKey + EQUALS);
-    }
-
-    private static int parseIntArgument(String argumentKey, String argument) {
-        return Integer.parseInt(argument.substring((argumentKey + EQUALS).length()));
-    }
-
-    private static String parseStringArgument(String argumentKey, String argument) {
-        return argument.substring((argumentKey + EQUALS).length());
     }
 }

--- a/src/test/resources/overview_file.txt
+++ b/src/test/resources/overview_file.txt
@@ -1,0 +1,1 @@
+'PR - Linux - JVM build - Latest Version', 'PR - Linux - Native build - Latest Version', 'PR - Windows - JVM build - Latest Version'


### PR DESCRIPTION
### Summary

This I plan to use in following workflows to limit bash scripting:

- https://github.com/quarkus-qe/quarkus-test-suite/blob/main/.github/workflows/add-flaky-test-label.yml
- https://github.com/quarkus-qe/quarkus-test-framework/blob/main/.github/workflows/add-flaky-test-label.yml

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)