### PR TITLE
Revert "Release 0.1.3 (3rd attempt)"

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,4 +1,4 @@
 name: Quarkus QE Test Framework
 release:
-  current-version: 0.1.3
-  next-version: 0.1.4
+  current-version: 0.1.2.Beta1
+  next-version: 0.1.3.Beta1


### PR DESCRIPTION
### Summary

This reverts commit 793c610f1ce43d9f3eb868563bd87323b768b5d1. Because https://github.com/quarkus-qe/flaky-run-reporter/pull/34 release workflow failed (yet another bug)

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)