### PR TITLE
Revert "Release 0.1.3 (4th attempt)"

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,4 +1,4 @@
 name: Quarkus QE Test Framework
 release:
-  current-version: 0.1.3
-  next-version: 0.1.4
+  current-version: 0.1.2.Beta1
+  next-version: 0.1.3.Beta1


### PR DESCRIPTION
### Summary

This reverts commit 4bce236728aeb966873f472c75b4226473751aa3 introduced in the https://github.com/quarkus-qe/flaky-run-reporter/pull/37 because release workflow failed https://github.com/quarkus-qe/flaky-run-reporter/actions/runs/11038360590/job/30661374371 over missing `maven-source-plugin`.

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [x] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)