### PR TITLE
Add Maven source plugin required by the release workflow

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,7 @@
     <properties>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
+        <source-plugin.version>3.3.1</source-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven-core.version>3.9.9</maven-core.version>
         <maven-surefire-report-parser.version>3.5.0</maven-surefire-report-parser.version>
@@ -168,6 +169,20 @@
                             <autoReleaseAfterClose>true</autoReleaseAfterClose>
                             <stagingProgressTimeoutMinutes>60</stagingProgressTimeoutMinutes>
                         </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-source-plugin</artifactId>
+                        <version>${source-plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <id>attach-sources</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>jar-no-fork</goal>
+                                </goals>
+                            </execution>
+                        </executions>
                     </plugin>
                 </plugins>
             </build>


### PR DESCRIPTION
### Summary

Adds Mavan source plugin as Nexus has following rules:

```
2024-09-25T17:55:21.0380119Z [INFO] [ERROR] Rule failure while trying to close staging repository with ID "ioquarkus-1975".
2024-09-25T17:55:21.0390600Z [INFO] [ERROR] 
2024-09-25T17:55:21.0391898Z [INFO] [ERROR] Nexus Staging Rules Failure Report
2024-09-25T17:55:21.0393694Z [INFO] [ERROR] ==================================
2024-09-25T17:55:21.0395152Z [INFO] [ERROR] 
2024-09-25T17:55:21.0396550Z [INFO] [ERROR] Repository "ioquarkus-1975" failures
2024-09-25T17:55:21.0408622Z [INFO] [ERROR]   Rule "sources-staging" failures
2024-09-25T17:55:21.0413360Z [INFO] [ERROR]     * Missing: no sources jar found in folder '/io/quarkus/qe/flaky-run-reporter/0.1.3'
2024-09-25T17:55:21.0416798Z [INFO] [ERROR] 
2024-09-25T17:55:21.0418475Z [INFO] [ERROR] 
2024-09-25T17:55:21.0421406Z [INFO] [ERROR] Cleaning up local stage directory after a Rule failure during close of staging repositories: [ioquarkus-1975]
2024-09-25T17:55:21.0424257Z [INFO] [ERROR]  * Deleting context b0c9d983f655b.properties
2024-09-25T17:55:21.0426997Z [INFO] [ERROR] Cleaning up remote stage repositories after a Rule failure during close of staging repositories: [ioquarkus-1975]
2024-09-25T17:55:21.0430255Z [INFO] [ERROR]  * Dropping failed staging repository with ID "ioquarkus-1975" (Rule failure during close of staging repositories: [ioquarkus-1975]).
```

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)