### PR TITLE
Fix order of release plugins

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,6 +115,32 @@
                 <plugins>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-source-plugin</artifactId>
+                        <version>${source-plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <id>attach-sources</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>jar-no-fork</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <version>3.10.0</version>
+                        <executions>
+                            <execution>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-release-plugin</artifactId>
                         <version>3.1.1</version>
                         <configuration>
@@ -147,18 +173,6 @@
                         </executions>
                     </plugin>
                     <plugin>
-                        <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>3.10.0</version>
-                        <executions>
-                            <execution>
-                                <phase>package</phase>
-                                <goals>
-                                    <goal>jar</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
                         <groupId>org.sonatype.plugins</groupId>
                         <artifactId>nexus-staging-maven-plugin</artifactId>
                         <version>1.7.0</version>
@@ -169,20 +183,6 @@
                             <autoReleaseAfterClose>true</autoReleaseAfterClose>
                             <stagingProgressTimeoutMinutes>60</stagingProgressTimeoutMinutes>
                         </configuration>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-source-plugin</artifactId>
-                        <version>${source-plugin.version}</version>
-                        <executions>
-                            <execution>
-                                <id>attach-sources</id>
-                                <phase>verify</phase>
-                                <goals>
-                                    <goal>jar-no-fork</goal>
-                                </goals>
-                            </execution>
-                        </executions>
                     </plugin>
                 </plugins>
             </build>


### PR DESCRIPTION
### Summary

In the last attempt for release I got:

```
2024-09-25T18:24:23.3551756Z [INFO] [ERROR] Nexus Staging Rules Failure Report
2024-09-25T18:24:23.3554445Z [INFO] [ERROR] ==================================
2024-09-25T18:24:23.3560114Z [INFO] [ERROR] 
2024-09-25T18:24:23.3563840Z [INFO] [ERROR] Repository "ioquarkus-1977" failures
2024-09-25T18:24:23.3565164Z [INFO] [ERROR]   Rule "signature-staging" failures
2024-09-25T18:24:23.3567908Z [INFO] [ERROR]     * Missing Signature: '/io/quarkus/qe/flaky-run-reporter/0.1.3/flaky-run-reporter-0.1.3-sources.jar.asc' does not exist for 'flaky-run-reporter-0.1.3-sources.jar'.
2024-09-25T18:24:23.3570852Z [INFO] [ERROR] 
```

My theory is that it is because GPG plugin run before source jars were generated. So order seems to matter, let's try it.

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)