### PR TITLE
Revert "Release 0.1.5"

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,4 +1,4 @@
 name: Quarkus QE Test Framework
 release:
-  current-version: 0.1.5
-  next-version: 0.1.6
+  current-version: 0.1.4
+  next-version: 0.1.5


### PR DESCRIPTION
Reverts quarkus-qe/flaky-run-reporter#74 because release failed over `Missing download info for radcortez/project-metadata-action@master` which I am going to fix.