### PR TITLE
Release 0.1.5

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,4 +1,4 @@
 name: Quarkus QE Test Framework
 release:
-  current-version: 0.1.4
-  next-version: 0.1.5
+  current-version: 0.1.5
+  next-version: 0.1.6


### PR DESCRIPTION
### Summary

Releases 0.1.5 in order to test https://github.com/quarkus-qe/flaky-run-reporter/pull/73. This release contains multiple dependency bumps and the most importantly https://github.com/quarkus-qe/flaky-run-reporter/pull/59. Starting with this release, we require Maven version greater or equal 3.9.6.

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [x] Release
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)